### PR TITLE
ui: reduced the height of the default sm height as we have reduce the

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A fuzzy terminal popup to manage and create tmux sessions using `fzf`.
 
 ![tmux session creator popup](./assets/session-creator.png)
 
-Just a simple and fast tmux workflow helper. It opens popups using `fzf` where you can:
+Just a simple and fast tmux workflow helper with a clean, minimal popup UI. It opens `fzf` popups where you can:
 
 - View and switch sessions quickly
 - Preview windows in the selected session
@@ -77,8 +77,8 @@ Inside the switcher popup:
 
 - **Type to search** - Fuzzy find sessions by name
 - **Enter** - Switch to selected session
-- **Ctrl-O** - Open session creator
-- **Ctrl-D** - Delete selected session
+- **Ctrl-o** - Open session creator
+- **Ctrl-d** - Delete selected session
 - **Ctrl-l** - Change the active window in selected session to next
 - **Ctrl-h** - Change the active window in selected session to previous
 - **Esc** - Close without switching
@@ -104,43 +104,26 @@ set -g @session_switcher_key 's'
 # Session creator key binding (default: 'j')
 set -g @session_create_key 'j'
 
-# Popup width (default: '80%')
-set -g @session_popup_width '80%'
+# Popup width (default: '60%')
+set -g @session_popup_width '60%'
 
-# Popup height (default: '60%')
-set -g @session_popup_height '60%'
-
-# Session switcher header (default: dynamic header with key hints)
-set -g @session_switcher_header ''
-
-# Session creator header (default: dynamic header with key hints)
-set -g @session_creator_header ''
+# Popup height (default: '40%')
+set -g @session_popup_height '40%'
 ```
 
 ### Popup Size (Current Default)
 
 Default popup size:
 
-- Width: `80%`
-- Height: `60%`
+- Width: `60%`
+- Height: `40%`
 
 To change popup size, set options in your `~/.tmux.conf`:
 
 ```bash
-set -g @session_popup_width '90%'
-set -g @session_popup_height '70%'
+set -g @session_popup_width '80%'
+set -g @session_popup_height '60%'
 ```
-
-### Custom Header Text
-
-You can override popup header text for both views:
-
-```bash
-set -g @session_switcher_header '󰆍 My Sessions | Ctrl-O new | Ctrl-D delete'
-set -g @session_creator_header '󱂬 Project Picker'
-```
-
-If these options are empty, the plugin uses dynamic default headers with key hints.
 
 ## Troubleshooting
 

--- a/main.tmux
+++ b/main.tmux
@@ -9,8 +9,8 @@ session_popup_height="$(tmux show-option -gqv "@session_popup_height")"
 
 session_switcher_key="${session_switcher_key:-s}"
 session_create_key="${session_create_key:-j}"
-session_popup_width="${session_popup_width:-80%}"
-session_popup_height="${session_popup_height:-60%}"
+session_popup_width="${session_popup_width:-60%}"
+session_popup_height="${session_popup_height:-40%}"
 
 tmux bind-key "$session_switcher_key" display-popup -E -B -w "$session_popup_width" -h "$session_popup_height" "bash '$current_dir/scripts/session-manager'"
 tmux bind-key "$session_create_key" display-popup -E -B -w "$session_popup_width" -h "$session_popup_height" "bash '$current_dir/scripts/sessionizer'"

--- a/scripts/session-list
+++ b/scripts/session-list
@@ -8,7 +8,7 @@ tmux list-sessions -F "#{session_activity}|#{session_name}|#{session_windows}|#{
     sort -t'|' -k1,1nr |
     awk -F'|' -v current="$current_session" '
         {
-            marker = ($2 == current) ? "●" : "○"
+            marker = ($2 == current) ? ">" : " "
             status = ($4 == "attached") ? " (attached)" : ""
             printf "%s\t%s\t%s\t%s  %-24s %3s%s\n", $2, $3, $4, marker, $2, $3, status
         }

--- a/scripts/session-list
+++ b/scripts/session-list
@@ -9,7 +9,6 @@ tmux list-sessions -F "#{session_activity}|#{session_name}|#{session_windows}|#{
     awk -F'|' -v current="$current_session" '
         {
             marker = ($2 == current) ? ">" : " "
-            status = ($4 == "attached") ? " (attached)" : ""
-            printf "%s\t%s\t%s\t%s  %-24s %3s%s\n", $2, $3, $4, marker, $2, $3, status
+            printf "%s\t%s\t%s\t%s  %-24s\n", $2, $3, $4, marker, $2
         }
     '

--- a/scripts/session-list
+++ b/scripts/session-list
@@ -9,6 +9,8 @@ tmux list-sessions -F "#{session_activity}|#{session_name}" |
     awk -F'|' -v current="$current_session" '
         {
             marker = ($2 == current) ? ">" : " "
+            # Column 1 keeps the raw session name for fzf placeholders ({1});
+            # column 2 is the visible label used with --with-nth=2.
             printf "%s\t%s  %-24s\n", $2, marker, $2
         }
     '

--- a/scripts/session-list
+++ b/scripts/session-list
@@ -2,13 +2,13 @@
 
 current_session="$(tmux display-message -p '#S')"
 
-# Fields: activity_timestamp|session_name|window_count|attached_state
-tmux list-sessions -F "#{session_activity}|#{session_name}|#{session_windows}|#{?session_attached,attached,detached}" |
+# Fields: activity_timestamp|session_name
+tmux list-sessions -F "#{session_activity}|#{session_name}" |
     # Sort by activity timestamp (field 1), numeric descending: most recent first.
     sort -t'|' -k1,1nr |
     awk -F'|' -v current="$current_session" '
         {
             marker = ($2 == current) ? ">" : " "
-            printf "%s\t%s\t%s\t%s  %-24s\n", $2, $3, $4, marker, $2
+            printf "%s\t%s  %-24s\n", $2, marker, $2
         }
     '

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -4,7 +4,6 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 switcher_key="$(tmux show-option -gqv "@session_switcher_key")"
 creator_key="$(tmux show-option -gqv "@session_create_key")"
-custom_switcher_header="$(tmux show-option -gqv "@session_switcher_header")"
 
 if [[ -z "$switcher_key" ]]; then
     switcher_key="$(tmux show-option -gqv "@session_manager_key")"
@@ -17,27 +16,18 @@ fi
 switcher_key="${switcher_key:-s}"
 creator_key="${creator_key:-j}"
 
-if [[ -n "$custom_switcher_header" ]]; then
-    header_text="$custom_switcher_header"
-else
-    header_text="󰆍 Session Switcher | Prefix+$creator_key: creator | Ctrl-O: new | Ctrl-D: delete"
-fi
-
 selected_session=$(
     bash "$script_dir/session-list" |
         fzf --reverse \
-            --prompt=" " \
-            --header="$header_text" \
-            --header-first \
             --ignore-case \
             --delimiter='\t' \
             --with-nth=4 \
             --color="header:italic,border:#908caa,pointer:#9ccfd8,marker:#eb6f92" \
             --border=rounded \
             --info=hidden \
-            --input-border=rounded \
-            --preview-border=rounded \
-            --preview-window=right:50%:wrap \
+            --input-border=none \
+            --preview-border=left \
+            --preview-window=right:50% \
             --preview="bash '$script_dir/session-preview' {1}" \
             --bind="ctrl-o:become(bash '$script_dir/sessionizer')" \
             --bind="ctrl-d:execute-silent(bash '$script_dir/delete-session' {1})+reload(bash '$script_dir/session-list')" \

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -13,7 +13,7 @@ selected_session=$(
         fzf --reverse \
             --ignore-case \
             --delimiter='\t' \
-            --with-nth=4 \
+            --with-nth=2 \
             --color="header:italic,border:#908caa,pointer:#9ccfd8,marker:#eb6f92" \
             --border=rounded \
             --info=hidden \

--- a/scripts/session-manager
+++ b/scripts/session-manager
@@ -5,14 +5,6 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 switcher_key="$(tmux show-option -gqv "@session_switcher_key")"
 creator_key="$(tmux show-option -gqv "@session_create_key")"
 
-if [[ -z "$switcher_key" ]]; then
-    switcher_key="$(tmux show-option -gqv "@session_manager_key")"
-fi
-
-if [[ -z "$creator_key" ]]; then
-    creator_key="$(tmux show-option -gqv "@session_creator_key")"
-fi
-
 switcher_key="${switcher_key:-s}"
 creator_key="${creator_key:-j}"
 

--- a/scripts/session-preview
+++ b/scripts/session-preview
@@ -3,8 +3,8 @@
 session="${1:-$(tmux display-message -p '#{session_name}')}"
 
 tmux list-windows -t "$session" \
-    -F '#{?window_active,▶, }|#{window_index}|#{window_name}|#{pane_current_command}|#{window_id}' |
+    -F '#{?window_active,>, }|#{window_index}|#{window_name}|#{pane_current_command}|#{window_id}' |
     awk -F'|' '{
-      printf "%s  %-1s  %-8s %-8s %s\n",
+      printf "%s  %-1s  %-12s %-12s %s\n",
              $1, $2, $3, $4, $5
     }'

--- a/scripts/sessionizer
+++ b/scripts/sessionizer
@@ -1,40 +1,18 @@
 #!/usr/bin/env bash
 
-switcher_key="$(tmux show-option -gqv "@session_switcher_key")"
-creator_key="$(tmux show-option -gqv "@session_create_key")"
-custom_creator_header="$(tmux show-option -gqv "@session_creator_header")"
-
-if [[ -z "$switcher_key" ]]; then
-    switcher_key="$(tmux show-option -gqv "@session_manager_key")"
-fi
-
-if [[ -z "$creator_key" ]]; then
-    creator_key="$(tmux show-option -gqv "@session_creator_key")"
-fi
-
-switcher_key="${switcher_key:-s}"
-creator_key="${creator_key:-j}"
-
-if [[ -n "$custom_creator_header" ]]; then
-    header_text="$custom_creator_header"
-else
-    header_text="󱂬 Session Creator | Prefix+$switcher_key: switcher | Prefix+$creator_key: creator"
-fi
-
 selected=$(
     find "$HOME" -mindepth 1 -maxdepth 4 \
         \( -name "node_modules" -o -name ".git" -o -name "target" \) -prune -o \
         -type d -print |
-        fzf --reverse --prompt=" " --header="$header_text" \
-            --header-first \
+        fzf --reverse \
             --color="header:italic,border:#908caa,pointer:#9ccfd8,marker:#eb6f92" \
             --border=rounded \
             --ignore-case \
             --wrap \
             --info=hidden \
-            --input-border=rounded \
+            --input-border=none \
             --preview='tree -C -L 3 {}' \
-            --preview-border=rounded \
+            --preview-border=left \
             --preview-window=right:50%:wrap
 )
 


### PR DESCRIPTION
mess

> removed the un necessary icons 
> removed the un necessary hint as key maps are less and only begin set it is easy for the user to do that 

> refacto fzf args as we are dont putting or nesting borders 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reduced default popup size to 60% width × 40% height.
  * Simplified session list output and markers; removed session/window counts and attachment state.
  * Streamlined selection UI: removed custom prompt/header, adjusted preview layout/wrapping and borders, and changed which fields are shown in the selector.

* **Documentation**
  * README updated to reflect new defaults, removed header options, simplified examples, and lowercase control key labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->