### PR TITLE
refacto: removed the unnecessary checking > as we will be in tmux session while running the tmux window command > with out begin in tmux session we cant launch window command of it so we remove it

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Inside the creator popup:
 
 - **Type to search** - Fuzzy find directories under `$HOME`
 - **Enter** - Create/switch to session named from directory basename
-- If tmux is not running, it starts a new tmux session
 - If the session exists, it switches/attaches to it
 - **Esc** - Close without creating/switching
 

--- a/scripts/sessionizer
+++ b/scripts/sessionizer
@@ -21,12 +21,6 @@ if [[ -z $selected ]]; then
 fi
 
 selected_name=$(basename "$selected" | tr . _)
-tmux_running=$(pgrep tmux)
-
-if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-    tmux new-session -s "$selected_name" -c "$selected"
-    exit 0
-fi
 
 if ! tmux has-session -t="$selected_name" 2>/dev/null; then
     tmux new-session -ds "$selected_name" -c "$selected"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected sessionizer behavior documentation to match current implementation.

* **Bug Fixes**
  * Updated sessionizer session initialization process to streamline session creation and attachment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->