### PR TITLE
feat: keymaps for session_manager will now support alt key

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ set -g @sessionizer_key 'j'
 # If you want to use sessionizer without <prefix> (e.g. Alt+i), you can do so by prepending -n:
 set -g @sessionizer_key '-n M-i'
 
+# Similar thing for session_manager
+set -g @session_manager_key '-n M-j'
+
 # session-manager popup height (default: '30%')
 set -g @session_manager_height '40%'
 

--- a/main.tmux
+++ b/main.tmux
@@ -20,7 +20,12 @@ session_manager_width="${session_manager_width:-40%}"
 sessionizer_height="${sessionizer_height:-60%}"
 sessionizer_width="${sessionizer_width:-60%}"
 
-tmux bind-key "$session_manager_key" display-popup -E -B -w "$session_manager_width" -h "$session_manager_height" "bash '$current_dir/scripts/session-manager'"
+if [[ "$session_manager_key" == *"-n"* ]]; then 
+    session_manager_key=$(echo "$session_manager_key" | awk '{print $NF}')
+    tmux bind-key -n "$session_manager_key" display-popup -E -B -w "$session_manager_width" -h "$session_manager_height" "bash '$current_dir/scripts/session-manager'"
+else 
+    tmux bind-key "$session_manager_key" display-popup -E -B -w "$session_manager_width" -h "$session_manager_height" "bash '$current_dir/scripts/session-manager'"
+fi
 
 if [[ "$sessionizer_key" == *"-n"* ]]; then
     sessionizer_key=$(echo "$sessionizer_key" | awk '{print $NF}')

--- a/main.tmux
+++ b/main.tmux
@@ -20,14 +20,14 @@ session_manager_width="${session_manager_width:-40%}"
 sessionizer_height="${sessionizer_height:-60%}"
 sessionizer_width="${sessionizer_width:-60%}"
 
-if [[ "$session_manager_key" == *"-n"* ]]; then 
+if [[ "$session_manager_key" == "-n"* ]]; then 
     session_manager_key=$(echo "$session_manager_key" | awk '{print $NF}')
     tmux bind-key -n "$session_manager_key" display-popup -E -B -w "$session_manager_width" -h "$session_manager_height" "bash '$current_dir/scripts/session-manager'"
 else 
     tmux bind-key "$session_manager_key" display-popup -E -B -w "$session_manager_width" -h "$session_manager_height" "bash '$current_dir/scripts/session-manager'"
 fi
 
-if [[ "$sessionizer_key" == *"-n"* ]]; then
+if [[ "$sessionizer_key" == "-n"* ]]; then
     sessionizer_key=$(echo "$sessionizer_key" | awk '{print $NF}')
     tmux bind-key -n "$sessionizer_key" display-popup -E -B -w "$sessionizer_width" -h "$sessionizer_height" "bash '$current_dir/scripts/sessionizer'"
 else


### PR DESCRIPTION
added condition for checking the key that is set as session_manager_key and
handled the case when there is -n option to have the key mapping working with alt key

updated dos with latest maps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session-manager key binding now supports usage without a prefix key (e.g., `M-j`).

* **Documentation**
  * Updated Custom Key Bindings section with examples for configuring session-manager without requiring a prefix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vimlinuz/tmux-sm/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->